### PR TITLE
Fix a broken link

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,7 +10,7 @@ The Pulumi Harness provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@lbrlabs/pulumi-harness`](https://www.npmjs.com/package/@lbrlabs/pulumi-harness)
 * Python: [`lbrlabs_pulumi_harness`](https://pypi.org/project/lbrlabs-pulumi-harness/)
-* Go: [`github.com/lbrlabs/pulumi-harness/sdk/go/harness`](https://pkg.go.dev/github.com/lbrlabs/pulumi-harness/sdk)
+* Go: [`github.com/lbrlabs/pulumi-harness/sdk/go/harness`](https://github.com/lbrlabs/pulumi-harness)
 * .NET: [`Lbrlabs.PulumiPackage.Harness`](https://www.nuget.org/packages/Lbrlabs.PulumiPackage.Harness)
 
 ### Provider Binary


### PR DESCRIPTION
Updates the Go SDK link to point to the top level of the repo. (It currently 404s.)